### PR TITLE
set severity level correctly

### DIFF
--- a/src/main/java/hudson/plugins/violations/types/cpplint/CppLintParser.java
+++ b/src/main/java/hudson/plugins/violations/types/cpplint/CppLintParser.java
@@ -74,7 +74,7 @@ public class CppLintParser implements ViolationsParser {
             violation.setLine(cppLintViolation.getLineStr());
             violation.setMessage(cppLintViolation.getMessage());
             violation.setSource(cppLintViolation.getViolationId());
-            setServerityLevel(violation, cppLintViolation.getViolationId());
+            setServerityLevel(violation, cppLintViolation.getConfidence());
 
             FullFileModel fileModel = getFileModel(model, 
             		cppLintViolation.getFileName(), 


### PR DESCRIPTION
Simple change to fix a bug in the CppLint parser where the severity level was not being set correctly. It is now set according to the confidence level not the message ID
