### PR TITLE
Fixes https://issues.jenkins-ci.org/browse/JENKINS-12764

### DIFF
--- a/src/main/java/hudson/plugins/violations/model/FileModel.java
+++ b/src/main/java/hudson/plugins/violations/model/FileModel.java
@@ -58,6 +58,24 @@ public class FileModel extends AbstractFileModel {
     }
 
     /**
+     * Get the display name of this file.
+     * @return the name to use whrn displaying the file violations.
+     */
+    @Override
+    public String getDisplayName() {
+        return super.getDisplayName();
+    }
+
+    /**
+     * Get the map of types to violations.
+     * @return the type to violation map.
+     */
+    @Override
+    public TreeMap<String, TreeSet<Violation>> getTypeMap() {
+        return super.getTypeMap();
+    }
+
+    /**
      * A overview class for each type.
      */
     public static class LimitType {


### PR DESCRIPTION
Taken from commit (https://github.com/vcarluer/violations-plugin/commit/b25c6e545834297938a76f039ac81244fb43a87d).  This fixes the problem with the Violations Summary.  All the other changes in PR https://github.com/jenkinsci/violations-plugin/pull/12 is extra.

This one change fixes the issue for Jenkins 1.457 at least.  Older versions of Violations plugin do not work on Jenkins  even though it works on Hudson builds.   Please review!  Thanks.
