### PR TITLE
Chart width resized

### DIFF
--- a/src/main/java/hudson/plugins/violations/ViolationsBuildAction.java
+++ b/src/main/java/hudson/plugins/violations/ViolationsBuildAction.java
@@ -28,7 +28,7 @@ public class ViolationsBuildAction
     private static final double LOG_VALUE_FOR_ZERO = 0.5;
     private boolean  useLog = false;
 
-    private static final int X_SIZE = 400;
+    private static final int X_SIZE = 500;
     private static final int Y_SIZE = 200;
     private static final double PADDING = 5.0;
 

--- a/src/main/java/hudson/plugins/violations/hudson/AbstractViolationsBuildAction.java
+++ b/src/main/java/hudson/plugins/violations/hudson/AbstractViolationsBuildAction.java
@@ -54,7 +54,7 @@ public abstract class AbstractViolationsBuildAction
     private static final double LOG_VALUE_FOR_ZERO = 0.5;
     private boolean  useLog = false;
 
-    private static final int X_SIZE = 400;
+    private static final int X_SIZE = 500;
     private static final int Y_SIZE = 200;
     private static final double PADDING = 5.0;
 


### PR DESCRIPTION
Hey there

Other Jenkins charts tend to have width of 500px. I just resized the chart for Violations plugin to conform with that. Would you check if it is worth to pull?

Cheers,

Jozsef
