### PR TITLE
JENKINS-14970: 'pattern' is not being persisted.

### DIFF
--- a/src/main/resources/hudson/plugins/violations/ViolationsPublisher/config.jelly
+++ b/src/main/resources/hudson/plugins/violations/ViolationsPublisher/config.jelly
@@ -146,7 +146,7 @@
                           <input name="${inst.name}.pattern"
                                  class="setting-input"
                                  type="text"
-                                 value="${inst.name.pattern}">
+                                 value="${inst.pattern}">
                           </input>
                         </td>
                       </tr>


### PR DESCRIPTION
This is a fix for JENKINS-14970: XML File pattern for JSLINT is not getting persisted. 

The pattern is being persisted but the property name used by the config page to display the persisted value was incorrect so it looked like it wasn't saved.
Corrected the name of the property from '${inst.name.pattern}' to ${inst.pattern}.