### PR TITLE
[JENKINS-13567] Diagnosis for an NPE.

### DIFF
--- a/src/main/java/hudson/plugins/violations/hudson/maven/ViolationsMavenReporter.java
+++ b/src/main/java/hudson/plugins/violations/hudson/maven/ViolationsMavenReporter.java
@@ -23,6 +23,7 @@ import hudson.Launcher;
 import org.apache.maven.project.MavenProject;
 import hudson.model.Action;
 import hudson.FilePath;
+import hudson.maven.MavenModuleSetBuild;
 
 public class ViolationsMavenReporter extends MavenReporter {
     private static final String VIOLATIONS = "violations";
@@ -93,7 +94,12 @@ public class ViolationsMavenReporter extends MavenReporter {
         FilePath targetPath = new FilePath(
             new File(build.getRootDir(), VIOLATIONS));
 
-        ViolationsReport report = build.getWorkspace().act(
+        FilePath workspace = build.getWorkspace();
+        if (workspace == null) {
+            MavenModuleSetBuild parent = build.getModuleSetBuild();
+            throw new IOException("No workspace for " + build + "; parent workspace: " + (parent != null ? parent.getWorkspace() : "N/A") + "; builtOnStr=" + build.getBuiltOnStr() + "; builtOn=" + build.getBuiltOn());
+        }
+        ViolationsReport report = workspace.act(
             new ViolationsCollector(true, targetPath, htmlPath, config));
         report.setConfig(config);
         report.setBuild(build);


### PR DESCRIPTION
Not exactly a fix for [JENKINS-13567](https://issues.jenkins-ci.org/browse/JENKINS-13567) but at least clearer diagnosis. `AbstractBuild.getWorkspace` is `@CheckForNull` for a reason.
