### PR TITLE
[JENKINS-12764] Missing Overview in Violations Plugin

### DIFF
--- a/src/main/java/hudson/plugins/violations/render/FileModelProxy.java
+++ b/src/main/java/hudson/plugins/violations/render/FileModelProxy.java
@@ -327,4 +327,53 @@ public class FileModelProxy  {
         b.append("</div>\n");
     }
 
+    public String getFileNameAlt() {
+        return new File(fileModel.getDisplayName()).getName();
+    }
+
+    public String getSummaryTable() {
+
+        StringBuilder gst = new StringBuilder();
+        int count = 0;
+
+        gst.append(" <table class='violations' width='100%'>\n");
+        gst.append("   <tr>\n");
+        gst.append("     <td class='violations-header'> # </td>\n");
+        gst.append("     <td class='violations-header'> Type </td>\n");
+        gst.append("     <td class='violations-header'> Class</td>\n");
+        gst.append("     <td class='violations-header'> Message</td>\n");
+        gst.append("     <td class='violations-header'> Description</td>\n");
+        gst.append("   </tr>\n");
+
+        Set<Violation> violations = fileModel.getLineViolationMap().get(0);
+
+        for (Violation v: violations) {
+            ++count;
+            gst.append("   <tr>\n");
+            gst.append("     <td class='violations'>");
+            gst.append(count);
+            gst.append("</td>\n");
+            gst.append("     <td class='violations'>");
+            gst.append(v.getType());
+            gst.append("</td>\n");
+            gst.append("     <td class='violations'>");
+            gst.append(v.getSource());
+            gst.append("</td>\n");
+            gst.append("     <td class='violations'>");
+            gst.append(v.getMessage());
+            gst.append("</td>\n");
+            gst.append("     <td class='violations'>");
+            gst.append(v.getPopupMessage());
+            gst.append("</td>\n");
+            gst.append("   </tr>\n");
+        }
+        //}
+        gst.append(" </table>\n");
+        gst.append("<p><br>\n");
+        gst.append("<h3>Total Number of violations:  \n");
+        gst.append(count);
+        gst.append("</h3><p>\n");
+        return gst.toString();
+    }
+
 }

--- a/src/main/resources/hudson/plugins/violations/render/FileModelProxy/index.jelly
+++ b/src/main/resources/hudson/plugins/violations/render/FileModelProxy/index.jelly
@@ -22,8 +22,9 @@
         value="${rootURL}/plugin/violations/images/16x16"/>
 
       <j:set var="href" value="${it.showLines}"/>
-      <h3><img src="${image}"/> ${model.displayName}</h3>
+      <h3><img src="${image}"/> ${it.fileNameAlt}</h3>
       
+      <j:out value="${it.summaryTable}"/>
       
       <j:forEach var="t" items="${model.typeMap.entrySet()}">
         <table class="pane">

--- a/src/main/webapp/css/style.css
+++ b/src/main/webapp/css/style.css
@@ -90,3 +90,38 @@ table.violationPopup th {
    border-spacing:  0;
    border-collapse: collapse;
 }
+
+.violations  {
+  margin-top: 4px;
+}
+.violations td {
+  padding: 4px 4px 3px 4px;
+}
+
+table.violations {
+  width: 100%;
+  border-collapse: collapse;
+  border: 1px #bbb solid;
+}
+table.violations > tbody > tr > td:last-child {
+  border-right: 1px #bbb solid;
+}
+
+td.violations {
+  border: 1px #bbb solid;
+  padding: 3px 4px 3px 4px;
+  vertical-align: middle;
+}
+
+td.violations-header {
+  border: 1px #bbb solid;
+  border-right: none;
+  border-left: none;
+  background-color: #f0f0f0;
+  font-weight: bold;
+}
+
+th.violations {
+  border: 1px #bbb solid;
+  font-weight: bold;
+}


### PR DESCRIPTION
Clicking on FxCop results leads to blank page

I Changed the plugin according to
http://stackoverflow.com/questions/15905131/clicking-on-fxcop-results-in-jenkins-violations-plugin-leads-to-blank-page and the
FxCop results are now shown