### PR TITLE
display violations when no source file is present

### DIFF
--- a/src/main/java/hudson/plugins/violations/render/FileModelProxy.java
+++ b/src/main/java/hudson/plugins/violations/render/FileModelProxy.java
@@ -2,6 +2,7 @@ package hudson.plugins.violations.render;
 
 import java.util.Map;
 import java.util.Set;
+import java.util.TreeSet;
 
 import hudson.Functions;
 import hudson.model.AbstractBuild;
@@ -121,6 +122,19 @@ public class FileModelProxy  {
         ret.append("</td></tr>\n");
     }
 
+    public Set<Map.Entry<String, TreeSet<Violation>>> getTypeMapEntries(){
+	return getFileModel().getTypeMap().entrySet();
+    }
+
+
+    public Set<Map.Entry<Integer, Set<Violation>>> getViolationEntries(){
+	return getFileModel().getLineViolationMap().entrySet();
+    }
+
+    public String getDisplayName(){
+	return getFileModel().getDisplayName();
+    }
+
     /**
      * This gets called from the index.jelly script to
      * render the marked up contents of the file.
@@ -133,6 +147,7 @@ public class FileModelProxy  {
         int previousLine = -1;
         int startLine = 0;
         int currentLine = -1;
+
         for (Map.Entry<Integer, String> e
                  : fileModel.getLines().entrySet()) {
             currentLine = e.getKey();
@@ -223,6 +238,15 @@ public class FileModelProxy  {
     }
 
     /**
+     * Get the URL for the icon, taking context into account
+     * @param v the violation
+     * @return URL
+     */
+    public String getSeverityIconUrl(Violation v){
+	return contextPath + getSeverityIcon(v.getSeverityLevel());
+    }
+
+    /**
      * Get the severity column for a violation.
      * @param v the violation.
      * @return a string to place in the severity column of the violation table.
@@ -232,9 +256,7 @@ public class FileModelProxy  {
         addVDiv(b);
         b.append("<a class='healthReport'>");
         b.append(
-            "<img src='"
-            + contextPath
-            + getSeverityIcon(v.getSeverityLevel())
+		 "<img src='" + getSeverityIconUrl(v)
             + "' alt='"
             + v.getSeverity()
             + "'/>");

--- a/src/main/resources/hudson/plugins/violations/render/FileModelProxy/index.jelly
+++ b/src/main/resources/hudson/plugins/violations/render/FileModelProxy/index.jelly
@@ -22,13 +22,19 @@
         value="${rootURL}/plugin/violations/images/16x16"/>
 
       <j:set var="href" value="${it.showLines}"/>
-      <h3><img src="${image}"/> ${model.displayName}</h3>
+      <h3><img src="${image}"/>${it.displayName}</h3>
       
       
-      <j:forEach var="t" items="${model.typeMap.entrySet()}">
+      <j:forEach var="t" items="${it.typeMapEntries}">
         <table class="pane">
-          <tbody>
-            <tr><td class="pane-header" colspan="5"><j:out value="${it.typeLine(t.key)}"/></td></tr>
+	  <thead>
+	    <tr>
+	      <td class="pane-header" colspan="5">
+		<j:out value="${it.typeLine(t.key)}"/>
+	      </td>
+	    </tr>
+	  </thead>
+          <tbody>            
             <j:forEach var="v" items="${t.value}">
               <tr>
                 <td class="pane">
@@ -41,7 +47,7 @@
                 </td>
                 <!--<td class="pane">${v.source}</td> -->
                 <td class="pane"><j:out value="${it.severityColumn(v)}"/></td>
-                <td class="pane" width="99%">${v.message}</td>
+                <td class="pane" width="99%" style="white-space:normal;"><j:out value="${v.message}"/></td>
               </tr>
             </j:forEach>
           </tbody>
@@ -49,7 +55,14 @@
         <p></p>
       </j:forEach>
 
-      <j:out value="${it.fileContent}"/>
+      <j:choose>
+	<j:when test="${it.showLines}">
+	  <j:out value="${it.fileContent}"/>
+	</j:when>
+	<j:otherwise>
+	  <p>FxCop could not determine source code location. See <a href="https://blogs.msdn.com/b/codeanalysis/archive/2007/05/12/faq-why-is-file-and-line-information-available-for-some-warnings-in-fxcop-but-not-for-others.aspx">FAQ: Why is file and line information available for some warnings in FxCop but not for others?</a> for explanations.</p>
+	</j:otherwise>
+      </j:choose>
 
       <!--
       <j:set var="line" value="${model.nextLine}"/>

--- a/src/main/webapp/css/style.css
+++ b/src/main/webapp/css/style.css
@@ -34,6 +34,7 @@ td.line {
 td.message {
    border-width:    0px 1px 0px 0px;
    width: 100%;
+   white-space: normal;
 }
 
 


### PR DESCRIPTION
Adds some more getter functions to expose data to the jelly view,
jelly was failing silently on a lot of directives.

When no source is present, displays a message with links to more
detail.

Tweaks some CSS to prevent horizontal scrollbars with long messages.

https://issues.jenkins-ci.org/browse/JENKINS-17548
