### PR TITLE
Turn off escaping for numberdiff as output may contain HTML

### DIFF
--- a/src/main/resources/hudson/plugins/violations/tags/numberdiff.jelly
+++ b/src/main/resources/hudson/plugins/violations/tags/numberdiff.jelly
@@ -1,4 +1,3 @@
-<?jelly escape-by-default='true'?>
 <j:jelly
   xmlns:j="jelly:core"
   xmlns:st="jelly:stapler"


### PR DESCRIPTION
There's an issue with escaping output in case of numberdiff jelly template. This causes following:

![screen shot 2013-12-03 at 18 35 07](https://f.cloud.github.com/assets/287584/1669063/72b2a51a-5c70-11e3-8c5f-b3218dab1bea.png)

I believe we can turn off escaping for this specific case and template.
