### PR TITLE
Make lines with violations red (now green)

### DIFF
--- a/src/main/webapp/css/style.css
+++ b/src/main/webapp/css/style.css
@@ -8,7 +8,7 @@ table.source {
 }
 
 .violation {
-   background:#CCFFCC;
+   background: #FFDDDD;
 }
 
 td.source {


### PR DESCRIPTION
Violations from its principle should be imho red as that's something bad/negative, now it's green:

![screen shot 2014-01-09 at 10 53 06](https://f.cloud.github.com/assets/287584/1877002/4ce3876e-791c-11e3-9bcc-348953a3ee71.png)

I used the same color github here uses for coloring deleted lines.

![screen shot 2014-01-09 at 10 56 22](https://f.cloud.github.com/assets/287584/1877020/b7cc1262-791c-11e3-892f-c4daf0fb5f1f.png)
