### PR TITLE
Fixing issue where JSLint-parser does not find source file

### DIFF
--- a/src/main/java/hudson/plugins/violations/types/jslint/JsLintParser.java
+++ b/src/main/java/hudson/plugins/violations/types/jslint/JsLintParser.java
@@ -1,18 +1,20 @@
 package hudson.plugins.violations.types.jslint;
 
+import hudson.plugins.violations.model.FullFileModel;
+import hudson.plugins.violations.model.Severity;
+import hudson.plugins.violations.model.Violation;
+import hudson.plugins.violations.parse.AbstractTypeParser;
+import hudson.plugins.violations.util.AbsoluteFileFinder;
+
+import java.io.File;
 import java.io.IOException;
 
 import org.xmlpull.v1.XmlPullParserException;
 
-import hudson.plugins.violations.model.FullFileModel;
-import hudson.plugins.violations.model.Severity;
-import hudson.plugins.violations.model.Violation;
-
-import hudson.plugins.violations.parse.AbstractTypeParser;
-
 public class JsLintParser extends AbstractTypeParser {
-
     static final String TYPE_NAME = "jslint";
+    
+    private AbsoluteFileFinder absoluteFileFinder = new AbsoluteFileFinder();
     
     /**
      * Parse the JSLint xml file.
@@ -25,6 +27,9 @@ public class JsLintParser extends AbstractTypeParser {
         expectNextTag("jslint");
         getParser().next(); // consume the "jslint" tag
         
+        absoluteFileFinder.addSourcePaths(getSourcePaths());
+        absoluteFileFinder.addSourcePath(getProjectPath().getAbsolutePath());
+        
         // loop thru the child elements, getting the "file" ones
         while (skipToTag("file")) {
             parseFileElement();
@@ -34,9 +39,11 @@ public class JsLintParser extends AbstractTypeParser {
     private void parseFileElement()
         throws IOException, XmlPullParserException {
 
-        String absoluteFileName = fixAbsolutePath(checkNotBlank("name"));
+        String fileName = fixAbsolutePath(checkNotBlank("name"));
+        File file = absoluteFileFinder.getFileForName(fileName);
+
         getParser().next(); // consume "file" tag
-        FullFileModel fileModel = getFileModel(absoluteFileName);
+        FullFileModel fileModel = getFileModel(fileName, file);
 
         // loop thru the child elements, getting the "issue" ones
         while (skipToTag("issue")) {

--- a/src/test/java/hudson/plugins/violations/ViolationsParserTest.java
+++ b/src/test/java/hudson/plugins/violations/ViolationsParserTest.java
@@ -21,7 +21,7 @@ public abstract class ViolationsParserTest {
         }
         
         FullBuildModel model = new FullBuildModel();
-        parser.parse(model, xmlFile.getParentFile(), xmlFile.getName(), null);
+        parser.parse(model, xmlFile.getParentFile(), xmlFile.getName(), new String[0]);
         model.cleanup();
         return model;
 	}


### PR DESCRIPTION
Fixing an issue where JSLint parser could not locate the source file of the script. Will now attempt to find the file both in the job workspace as well as using the source paths provided in the violations configuration.

While #13 fixed the issue of the errors not being shown at all, it still only shows the errors without marking them in the file.
![violations-plugin-jslint-current](https://cloud.githubusercontent.com/assets/275651/4175404/a255a5d0-35d0-11e4-813a-04cc250b839b.png)

This patch will at least attempt to find the correct file, and show the contents like it does with other parsers:
![violations-plugin-jslint-fixed](https://cloud.githubusercontent.com/assets/275651/4175405/a7568072-35d0-11e4-8c0e-e4f9aa66a9d1.png)

