### PR TITLE
Fix URL escape

### DIFF
--- a/src/main/resources/hudson/plugins/violations/ViolationsReport/index.jelly
+++ b/src/main/resources/hudson/plugins/violations/ViolationsReport/index.jelly
@@ -30,7 +30,7 @@
           </tr>
           <j:forEach var="t" items="${model.typeCounts}">
             <tr>
-              <td class="pane"><a href="#${t.name}">${t.name}</a></td>
+              <td class="pane"><a href="#${t.name.replaceAll('\\','\%5C')}">${t.name}</a></td>
               <td class="pane">
                 <v:numberdiff curr="${it.typeCount(t.name)}"
                               prev="${prev.typeCount(t.name)}"/>


### PR DESCRIPTION
Fix per file report is not shown on Windows Server.
- Replace backslash to %5c in link.