### PR TITLE
Fixing 'no violations found' file links on Windows (Issue #50)

### DIFF
--- a/src/main/java/hudson/plugins/violations/ViolationsReport.java
+++ b/src/main/java/hudson/plugins/violations/ViolationsReport.java
@@ -211,7 +211,7 @@ public class ViolationsReport implements Serializable {
         if (name.startsWith("/")) {
             name = name.substring(1);
         }
-        FileModelProxy proxy = getFileModelProxy(name);
+        FileModelProxy proxy = getFileModelProxy(name.replace("/", File.separator));
         if (proxy != null) {
             return new RecurDynamic("", name, proxy.build(build).contextPath(""));
         } else {


### PR DESCRIPTION
This is the fix as described in [issue 50](https://github.com/jenkinsci/violations-plugin/issues/50).  I ran across the issue on Jenkins running on Windows server.  The problem is that all the file keys in the FileModelProxy use the file separator for the system (*nix='/', windows='\'), but the `String name` here comes from `getRestOfPath()` which prefers the url forward slash (which doesn't work for the Windows keys).  To transform the "rest of path" to the true file key, we must convert any '/' in the name to the File.separator for the system.
