### PR TITLE
Only include path if non-empty on codenarc filenames

### DIFF
--- a/src/main/java/hudson/plugins/violations/types/codenarc/CodenarcParser.java
+++ b/src/main/java/hudson/plugins/violations/types/codenarc/CodenarcParser.java
@@ -95,7 +95,10 @@ public class CodenarcParser extends AbstractTypeParser {
         if (sourceDirectory != null && !sourceDirectory.isEmpty()) {
             sourcePath += "/" + sourceDirectory;
         }
-        String absoluteFileName = fixAbsolutePath(sourcePath + "/" + path + "/" + checkNotBlank("name"));
+        if (!path.isEmpty()) {
+            sourcePath += "/" + path;
+        }
+        String absoluteFileName = fixAbsolutePath(sourcePath + "/" + checkNotBlank("name"));
         getParser().next(); // consume "file" tag
         FullFileModel fileModel = getFileModel(absoluteFileName);
 

--- a/src/test/java/hudson/plugins/violations/types/codenarc/CodenarcParserHudsonTest.java
+++ b/src/test/java/hudson/plugins/violations/types/codenarc/CodenarcParserHudsonTest.java
@@ -13,7 +13,7 @@ public class CodenarcParserHudsonTest extends JenkinsRule {
 
     @Test
     public void testThatCodenarcWithEmptyPathCanBeParsed() throws Exception {
-        violationsReport(CODENARC).reportedIn("**/CodeNarcReportEmptyPath.xml").perform().assertThat("/Test.groovy")
+        violationsReport(CODENARC).reportedIn("**/CodeNarcReportEmptyPath.xml").perform().assertThat("Test.groovy")
                 .wasReported().reportedViolation(192, "EmptyCatchBlock", "EmptyCatchBlock");
     }
 }


### PR DESCRIPTION
As a result of the fix for JENKINS-19260, an empty path gets appended to the filename of a codenarc file that was in the default package. This results in file paths that have two forward-slashes in them (e.g., `source-dir//Test.groovy`), ultimately causing the UI to not serve these files and show the violations within them. 

This PR checks if the path is empty, and if it is, does not include it in the file path. Also, the test case for this condition has been updated properly. 
