### PR TITLE
Added basic pipeline support. Very rudimentary still

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>org.jenkins-ci.plugins</groupId>
     <artifactId>plugin</artifactId>
-    <version>1.580.3</version>
+    <version>2.15</version>
     <relativePath />
   </parent>
 
@@ -101,8 +101,8 @@
        <!--
         Jenkins started to require Java 7 in 1.612 released 2015-05-03.
         -->
-       <source>1.6</source>
-       <target>1.6</target>
+       <source>1.7</source>
+       <target>1.7</target>
        </configuration>
      </plugin>
     </plugins>
@@ -134,6 +134,11 @@
       <groupId>org.jenkins-ci.main</groupId>
       <artifactId>maven-plugin</artifactId>
       <version>2.9</version>
+    </dependency>
+    <dependency>
+        <groupId>org.jenkins-ci.plugins.workflow</groupId>
+        <artifactId>workflow-step-api</artifactId>
+        <version>1.14</version>
     </dependency>
     <dependency>
       <groupId>xpp3</groupId>

--- a/src/main/java/hudson/plugins/violations/ViolationsBuildAction.java
+++ b/src/main/java/hudson/plugins/violations/ViolationsBuildAction.java
@@ -6,6 +6,7 @@ import hudson.maven.MavenBuild;
 import hudson.maven.MavenModule;
 import hudson.maven.MavenModuleSetBuild;
 import hudson.model.AbstractBuild;
+import hudson.model.Run;
 import hudson.plugins.violations.hudson.AbstractViolationsBuildAction;
 import hudson.plugins.violations.hudson.maven.ViolationsMavenAggregatedBuildAction;
 
@@ -40,7 +41,7 @@ public class ViolationsBuildAction
      * @param report the report for this build.
      */
     public ViolationsBuildAction(
-        AbstractBuild<?, ?> owner,
+        Run<?, ?> owner,
         ViolationsReport report) {
         super(owner);
         this.report = report;
@@ -55,7 +56,7 @@ public class ViolationsBuildAction
      * @param owner the build that has created this action.
      */
     public ViolationsBuildAction(
-        AbstractBuild<?, ?> owner) {
+        Run<?, ?> owner) {
         super(owner);
     }
 

--- a/src/main/java/hudson/plugins/violations/ViolationsProjectAction.java
+++ b/src/main/java/hudson/plugins/violations/ViolationsProjectAction.java
@@ -1,6 +1,7 @@
 package hudson.plugins.violations;
 
 import hudson.model.AbstractProject;
+import hudson.model.Job;
 import hudson.plugins.violations.hudson.AbstractViolationsProjectAction;
 
 /**
@@ -13,7 +14,7 @@ public class ViolationsProjectAction
      * Create a project action for the violations.
      * @param project the current project.
      */
-    public  ViolationsProjectAction(AbstractProject<?, ?> project) {
+    public  ViolationsProjectAction(Job<?, ?> project) {
         super(project);
     }
 

--- a/src/main/java/hudson/plugins/violations/hudson/AbstractViolationsProjectAction.java
+++ b/src/main/java/hudson/plugins/violations/hudson/AbstractViolationsProjectAction.java
@@ -10,6 +10,8 @@ import hudson.model.Action;
 import hudson.model.Actionable;
 import hudson.model.AbstractProject;
 import hudson.model.AbstractBuild;
+import hudson.model.Job;
+import hudson.model.Run;
 
 import hudson.plugins.violations.MagicNames;
 
@@ -21,13 +23,13 @@ public abstract class AbstractViolationsProjectAction
     implements Action, StaplerProxy
     //,  ProminentProjectAction
 {
-    private final AbstractProject<?, ?> project;
+    private final Job<?, ?> project;
 
     /**
      * Create a project action for the violations.
      * @param project the current project.
      */
-    public AbstractViolationsProjectAction(AbstractProject<?, ?> project) {
+    public AbstractViolationsProjectAction(Job<?, ?> project) {
         this.project = project;
     }
 
@@ -35,7 +37,7 @@ public abstract class AbstractViolationsProjectAction
      * Get the project.
      * @return the project.
      */
-    public AbstractProject<?, ?> getProject() {
+    public Job<?, ?> getProject() {
         return project;
     }
 
@@ -106,7 +108,7 @@ public abstract class AbstractViolationsProjectAction
      */
     public AbstractViolationsBuildAction getViolationsAction() {
 
-        for (AbstractBuild<?, ?> b = getProject().getLastBuild();
+        for (Run<?, ?> b = getProject().getLastBuild();
              b != null;
              b = b.getPreviousBuild()) {
             AbstractViolationsBuildAction ret = b.getAction(

--- a/src/main/java/hudson/plugins/violations/pipeline/ReportViolationsStep.java
+++ b/src/main/java/hudson/plugins/violations/pipeline/ReportViolationsStep.java
@@ -1,0 +1,34 @@
+package hudson.plugins.violations.pipeline;
+
+import hudson.Extension;
+import org.jenkinsci.plugins.workflow.steps.AbstractStepDescriptorImpl;
+import org.jenkinsci.plugins.workflow.steps.AbstractStepImpl;
+import org.kohsuke.stapler.DataBoundConstructor;
+import javax.annotation.Nonnull;
+
+/**
+ *
+ * @author bushc
+ */
+public class ReportViolationsStep extends AbstractStepImpl {
+    @DataBoundConstructor
+    public ReportViolationsStep(){}
+    
+    @Extension
+    public static class ReportViolationsDescriptorImpl extends AbstractStepDescriptorImpl {
+        
+        public ReportViolationsDescriptorImpl(){ super(ReportViolationsStepExecution.class); }
+        
+        @Override
+        public String getFunctionName(){
+            return "reportViolations";
+        }
+        
+        @Nonnull
+        @Override
+        public String getDisplayName(){
+            return "Scan for static analysis violations";
+        }
+        
+    }
+}

--- a/src/main/java/hudson/plugins/violations/pipeline/ReportViolationsStepExecution.java
+++ b/src/main/java/hudson/plugins/violations/pipeline/ReportViolationsStepExecution.java
@@ -1,0 +1,39 @@
+package hudson.plugins.violations.pipeline;
+
+import hudson.FilePath;
+import hudson.Launcher;
+import hudson.model.Run;
+import hudson.model.TaskListener;
+import hudson.plugins.violations.ViolationsPublisher;
+import org.jenkinsci.plugins.workflow.steps.AbstractSynchronousNonBlockingStepExecution;
+import org.jenkinsci.plugins.workflow.steps.StepContextParameter;
+
+/**
+ *
+ * @author bushc
+ */
+public class ReportViolationsStepExecution extends AbstractSynchronousNonBlockingStepExecution<Void> {
+    
+    @StepContextParameter
+    private transient TaskListener listener;
+    
+    @StepContextParameter
+    private transient FilePath ws;
+    
+    @StepContextParameter
+    private transient Run build;
+    
+    @StepContextParameter
+    private transient Launcher launcher;
+    
+    
+    @Override
+    protected Void run() throws Exception {
+        listener.getLogger().println("Analyzing static analysis output.");
+        
+        ViolationsPublisher publisher = new ViolationsPublisher();
+        publisher.perform(build, ws, launcher, listener);
+        
+        return null;
+    }
+}

--- a/src/main/java/hudson/plugins/violations/render/FileModelProxy.java
+++ b/src/main/java/hudson/plugins/violations/render/FileModelProxy.java
@@ -21,6 +21,7 @@ import java.util.TreeSet;
 import java.util.logging.Logger;
 
 import com.google.common.base.Supplier;
+import hudson.model.Run;
 
 /**
  * A proxy class for FileModel used to allow lazy loading of FileModel. This
@@ -49,7 +50,7 @@ public class FileModelProxy {
         }
     });
     private String contextPath;
-    private AbstractBuild<?, ?> build;
+    private Run<?, ?> build;
 
     /**
      * Construct this proxy.
@@ -68,7 +69,7 @@ public class FileModelProxy {
      *            the owner build.
      * @return this object.
      */
-    public FileModelProxy build(AbstractBuild<?, ?> build) {
+    public FileModelProxy build(Run<?, ?> build) {
         this.build = build;
         return this;
     }
@@ -90,7 +91,7 @@ public class FileModelProxy {
      *
      * @return the current build.
      */
-    public AbstractBuild<?, ?> getBuild() {
+    public Run<?, ?> getBuild() {
         return build;
     }
 

--- a/src/main/java/hudson/plugins/violations/render/NoViolationsFile.java
+++ b/src/main/java/hudson/plugins/violations/render/NoViolationsFile.java
@@ -1,20 +1,21 @@
 package hudson.plugins.violations.render;
 
 import hudson.model.AbstractBuild;
+import hudson.model.Run;
 
 /**
  * Class for rendering no violations.
  */
 public class NoViolationsFile {
     private final String name;
-    private final AbstractBuild<?, ?>  build;
+    private final Run<?, ?>  build;
 
     /**
      * Create a new no violations render page.
      * @param name the name of the file.
      * @param build the build.
      */
-    public NoViolationsFile(String name, AbstractBuild<?, ?> build) {
+    public NoViolationsFile(String name, Run<?, ?> build) {
         this.name = name;
         this.build = build;
     }
@@ -31,7 +32,7 @@ public class NoViolationsFile {
      * Get the build object.
      * @return the build for this page.
      */
-    public AbstractBuild<?, ?> getBuild() {
+    public Run<?, ?> getBuild() {
         return build;
     }
 }

--- a/src/test/java/hudson/plugins/violations/ViolationsReportBuilder.java
+++ b/src/test/java/hudson/plugins/violations/ViolationsReportBuilder.java
@@ -10,6 +10,7 @@ import hudson.FilePath;
 import hudson.model.Build;
 import hudson.model.BuildListener;
 import hudson.model.AbstractBuild;
+import hudson.model.Run;
 
 import java.io.File;
 
@@ -41,7 +42,7 @@ public class ViolationsReportBuilder {
         FilePath workspace = new FilePath(projectRootDir());
         FilePath targetPath = new FilePath(new File(projectRootDir().getPath() + "/" + VIOLATIONS));
         FilePath htmlPath = new FilePath(projectRootDir());
-        AbstractBuild<?, ?> build = mock(Build.class);
+        Run<?, ?> build = mock(Build.class);
         when(build.getRootDir()).thenReturn(projectRootDir());
         BuildListener listener = mock(BuildListener.class);
         ViolationsReport violationsReport = createBuildAction(workspace, targetPath, htmlPath, config, build, listener)


### PR DESCRIPTION
This provides very, very basic pipeline support. It needs to be cleaned up, but for anybody wanting to use it, it's here. Usage is:

`step([$class: 'ViolationsPublisher', type: 'fxcop', sunny: 10, stormy: 999, unstable: 999, pattern: '**/outputfile.analysis.xml', autoUpdateStormyThreshold: true, autoUpdateUnstableThreshold: true])`
