### PR TITLE
Remove usage of deprecated IOException2

### DIFF
--- a/src/main/java/hudson/plugins/violations/ViolationsCollector.java
+++ b/src/main/java/hudson/plugins/violations/ViolationsCollector.java
@@ -8,7 +8,6 @@ import hudson.plugins.violations.model.FullFileModel;
 import hudson.plugins.violations.model.Violation;
 import hudson.plugins.violations.util.StringUtil;
 import hudson.remoting.VirtualChannel;
-import hudson.util.IOException2;
 
 import java.io.File;
 import java.io.IOException;
@@ -37,7 +36,7 @@ public class ViolationsCollector implements FileCallable<ViolationsReport> {
 
     /**
      * Constructor.
-     * 
+     *
      * @param mavenProject
      *            true if this a maven project, false otherwise
      * @param targetDir
@@ -59,7 +58,7 @@ public class ViolationsCollector implements FileCallable<ViolationsReport> {
 
     /**
      * Create a report.
-     * 
+     *
      * @param workspace
      *            the current workspace.
      * @param channel
@@ -121,7 +120,7 @@ public class ViolationsCollector implements FileCallable<ViolationsReport> {
         try {
             new GenerateXML(targetDir, model, config).execute();
         } catch (InterruptedException ex) {
-            throw new IOException2(ex);
+            throw new IOException(ex);
         }
 
         // -----

--- a/src/main/java/hudson/plugins/violations/parse/AbstractTypeParser.java
+++ b/src/main/java/hudson/plugins/violations/parse/AbstractTypeParser.java
@@ -7,8 +7,6 @@ import java.io.Reader;
 import org.xmlpull.v1.XmlPullParser;
 import org.xmlpull.v1.XmlPullParserFactory;
 
-import hudson.util.IOException2;
-
 import hudson.plugins.violations.ViolationsParser;
 
 import hudson.plugins.violations.model.FullBuildModel;
@@ -59,7 +57,7 @@ public abstract class AbstractTypeParser
         } catch (IOException ex) {
             throw ex;
         } catch (Exception ex) {
-            throw new IOException2("Cannot parse " + fileName, ex);
+            throw new IOException("Cannot parse " + fileName, ex);
         } finally {
             CloseUtil.close(in, !success);
         }

--- a/src/main/java/hudson/plugins/violations/parse/ParseTypeXML.java
+++ b/src/main/java/hudson/plugins/violations/parse/ParseTypeXML.java
@@ -2,7 +2,6 @@ package hudson.plugins.violations.parse;
 
 import hudson.plugins.violations.model.FullBuildModel;
 import hudson.plugins.violations.util.CloseUtil;
-import hudson.util.IOException2;
 
 import java.io.File;
 import java.io.FileInputStream;
@@ -57,7 +56,7 @@ public class ParseTypeXML {
         } catch (IOException ex) {
             throw ex;
         } catch (Exception ex) {
-            throw new IOException2(ex);
+            throw new IOException(ex);
         } finally {
             CloseUtil.close(in, !success);
         }

--- a/src/main/java/hudson/plugins/violations/parse/ParseXML.java
+++ b/src/main/java/hudson/plugins/violations/parse/ParseXML.java
@@ -1,7 +1,6 @@
 package hudson.plugins.violations.parse;
 
 import hudson.plugins.violations.util.CloseUtil;
-import hudson.util.IOException2;
 
 import java.io.File;
 import java.io.FileInputStream;
@@ -45,7 +44,7 @@ public final class ParseXML {
         } catch (IOException ex) {
             throw ex;
         } catch (Exception ex) {
-            throw new IOException2(ex);
+            throw new IOException(ex);
         }
     }
 
@@ -74,7 +73,7 @@ public final class ParseXML {
             throw ex;
         } catch (Exception ex) {
             seenException = true;
-            throw new IOException2(ex);
+            throw new IOException(ex);
         } finally {
             CloseUtil.close(in, seenException);
         }

--- a/src/main/java/hudson/plugins/violations/parse/ViolationsDOMParser.java
+++ b/src/main/java/hudson/plugins/violations/parse/ViolationsDOMParser.java
@@ -2,7 +2,6 @@ package hudson.plugins.violations.parse;
 
 import hudson.plugins.violations.model.FullBuildModel;
 import hudson.plugins.violations.model.FullFileModel;
-import hudson.util.IOException2;
 
 import java.io.IOException;
 import java.io.File;
@@ -16,7 +15,7 @@ import org.w3c.dom.Document;
 import org.w3c.dom.Element;
 
 import hudson.plugins.violations.ViolationsParser;
-   
+
 public abstract class ViolationsDOMParser
     implements ViolationsParser {
 
@@ -65,7 +64,7 @@ public abstract class ViolationsDOMParser
         } catch (IOException ex) {
             throw ex;
         } catch (Exception ex) {
-            throw new IOException2("Cannot parse " + fileName, ex);
+            throw new IOException("Cannot parse " + fileName, ex);
         } finally {
             // ? terminate the parser
         }

--- a/src/main/java/hudson/plugins/violations/types/fxcop/FxCopParser.java
+++ b/src/main/java/hudson/plugins/violations/types/fxcop/FxCopParser.java
@@ -5,7 +5,6 @@ import hudson.plugins.violations.model.FullBuildModel;
 import hudson.plugins.violations.model.FullFileModel;
 import hudson.plugins.violations.model.Severity;
 import hudson.plugins.violations.model.Violation;
-import hudson.util.IOException2;
 
 import java.io.File;
 import java.io.FileInputStream;
@@ -23,8 +22,8 @@ import org.xml.sax.SAXException;
 
 /**
  * Parses a fxcop xml report file.
- * 
- * 
+ *
+ *
  * This does not uses the XML Pull parser as it can not handle the FxCop XML
  * files. The bug is registered at Sun as http: //bugs.sun.com/bugdatabase/view_bug.do?bug_id=4508058
  */
@@ -37,7 +36,7 @@ public class FxCopParser implements ViolationsParser {
     public void parse(FullBuildModel model, File projectPath, String fileName, String[] sourcePaths) throws IOException {
         this.projectPath = projectPath;
         this.model = model;
-        
+
         DocumentBuilderFactory docBuilderFactory = DocumentBuilderFactory.newInstance();
         DocumentBuilder docBuilder;
         try {
@@ -52,9 +51,9 @@ public class FxCopParser implements ViolationsParser {
             parseTargets(XmlElementUtil.getFirstElementByTagName(rootElement, "Targets"));
             // TODO parse notes
         } catch (ParserConfigurationException pce) {
-            throw new IOException2(pce);
+            throw new IOException(pce);
         } catch (SAXException se) {
-            throw new IOException2(se);
+            throw new IOException(se);
         }
     }
 
@@ -170,13 +169,13 @@ public class FxCopParser implements ViolationsParser {
         violation.setType("fxcop");
         violation.setSource(category + "#" + checkId);
         setSeverityLevel(violation, getString(issue, "Level"));
-        
+
         StringBuilder msgBuilder = new StringBuilder();
         if (subName != null) {
         	msgBuilder.append(subName);
         	msgBuilder.append(" ");
         }
-        
+
         FxCopRule rule = ruleSet.getRule(category, checkId);
         if (rule != null) {
         	msgBuilder.append("<a href=\"");

--- a/src/main/java/hudson/plugins/violations/types/gendarme/GendarmeParser.java
+++ b/src/main/java/hudson/plugins/violations/types/gendarme/GendarmeParser.java
@@ -8,7 +8,6 @@ import hudson.plugins.violations.model.Violation;
 import hudson.plugins.violations.parse.ParseUtil;
 import hudson.plugins.violations.types.fxcop.XmlElementUtil;
 import hudson.plugins.violations.util.AbsoluteFileFinder;
-import hudson.util.IOException2;
 
 import java.io.File;
 import java.io.FileInputStream;
@@ -38,46 +37,46 @@ import org.xml.sax.SAXException;
 public class GendarmeParser implements ViolationsParser {
 
 	static final Logger logger = Logger.getLogger(GendarmeParser.class.toString());
-	
+
 	static final String TYPE_NAME = "gendarme";
 	private FullBuildModel model;
     private File reportParentFile;
     private File projectPath;
     private String[] sourcePaths;
     private HashMap<String, GendarmeRule> rules;
-	
+
 	public void parse(FullBuildModel model, File projectPath, String fileName,
 			String[] sourcePaths) throws IOException {
 		logger.info("Starting Gendarme parsing");
-		
+
 		this.projectPath = projectPath;
         this.model = model;
         this.reportParentFile = new File(fileName).getParentFile();
         this.sourcePaths = sourcePaths;
-        
+
 		DocumentBuilderFactory docBuilderFactory = DocumentBuilderFactory.newInstance();
-		DocumentBuilder docBuilder;		
+		DocumentBuilder docBuilder;
 		try {
 			docBuilder = docBuilderFactory.newDocumentBuilder();
 			Document doc = docBuilder.parse(new FileInputStream(new File(projectPath, fileName)));
-			
+
 			NodeList mainNode = doc.getElementsByTagName("gendarme-output");
-			
+
 			Element rootElement = (Element) mainNode.item(0);
 			Element resultsElement = (Element)rootElement.getElementsByTagName("results").item(0);
 			Element rulesElement = (Element)rootElement.getElementsByTagName("rules").item(0);
-			
+
 			// load all rules into the cache
 			parseRules(XmlElementUtil.getNamedChildElements(rulesElement, "rule"));
-			
+
 			// parse each violations
             parseViolations(XmlElementUtil.getNamedChildElements(resultsElement, "rule"));
-            
+
 		} catch (ParserConfigurationException pce) {
-			throw new IOException2(pce);
+			throw new IOException(pce);
 		} catch (SAXException se) {
-			throw new IOException2(se);
-		}		
+			throw new IOException(se);
+		}
 	}
 
 	private void parseViolations(List<Element> ruleElements) {
@@ -86,19 +85,19 @@ public class GendarmeParser implements ViolationsParser {
 		AbsoluteFileFinder finder = new AbsoluteFileFinder();
 		// add the project path to the search source
         finder.addSourcePath(this.projectPath.getPath());
-        // if there's additional paths, add them too 
+        // if there's additional paths, add them too
         if (this.sourcePaths != null) {
             finder.addSourcePaths(this.sourcePaths);
         }
-        
+
 		for(Element ruleElement : ruleElements){
 			String ruleName = ruleElement.getAttribute("Name");
 			GendarmeRule rule =  this.rules.get(ruleName);
 			String problem = ruleElement.getElementsByTagName("problem").item(0).getTextContent();
 			String solution = ruleElement.getElementsByTagName("solution").item(0).getTextContent();
-			
+
 			List<Element> targetElements = XmlElementUtil.getNamedChildElements(ruleElement, "target");
-						
+
 			for(Element targetElement : targetElements){
 				//String targetName = targetElement.getAttribute("Name");
 				String targetAssembly = targetElement.getAttribute("Assembly");
@@ -113,12 +112,12 @@ public class GendarmeParser implements ViolationsParser {
 					String filePath = "";
 					String fileName = "";
 					int line = 0;
-	
+
 					if(rule.getType() != GendarmeRuleType.Assembly){
 						Pattern pattern = Pattern.compile("^(.*)\\(.([0-9]*)\\)$");
 						Matcher matcher = pattern.matcher(source);
 						logger.info("matcher.groupCount() : "+matcher.groupCount());
-						
+
 						logger.info("matcher.matches() : "+matcher.matches());
 						logger.info("source : "+source);
 						if(matcher.matches()) {
@@ -131,13 +130,13 @@ public class GendarmeParser implements ViolationsParser {
 							File sourceFile = new File(fullPath);
 							fileName = sourceFile.getName();
 							filePath = sourceFile.getParent();
-							line = Integer.parseInt(matcher.group(2)); 
+							line = Integer.parseInt(matcher.group(2));
 						}
 					}
-					
+
 					// create the violation
 					Violation violation = new Violation();
-	
+
 					// construct the error message
 					StringBuilder messageBuilder = new StringBuilder();
 					if(rule.getUrl() != null){
@@ -148,14 +147,14 @@ public class GendarmeParser implements ViolationsParser {
 					else {
 						messageBuilder.append(rule.getName());
 					}
-					
+
 					messageBuilder.append(" - ").append(problem).append("<br/>");
 					messageBuilder.append("Solution: ").append(solution).append("<br/>");
 					messageBuilder.append("Confidence: ").append(confidence);
-					
+
 					violation.setMessage(messageBuilder.toString());
-					violation.setPopupMessage(problem);	
-					
+					violation.setPopupMessage(problem);
+
 					// construct the severity
 					if(severityString.equals("Low")){
 						violation.setSeverityLevel(Severity.LOW_VALUE);
@@ -179,7 +178,7 @@ public class GendarmeParser implements ViolationsParser {
 					}
 					violation.setType(TYPE_NAME);
 					violation.setSource(rule.getName());
-	
+
 					// try to get the file
 					// TODO : test it with Linux Master => Windows Slave node. Unix/Windows path could be a problem.
 					FullFileModel fileModel;
@@ -220,12 +219,12 @@ public class GendarmeParser implements ViolationsParser {
 			}
 		}
 	}
-	
+
 	private void parseRules(List<Element> ruleElements) {
 		rules = new HashMap<String, GendarmeRule>();
-		
+
 		for(Element ruleElement : ruleElements){
-			
+
 			// create the Gendarme rule
 			GendarmeRule rule = new GendarmeRule();
 			rule.setName(ruleElement.getAttribute("Name"));
@@ -242,7 +241,7 @@ public class GendarmeParser implements ViolationsParser {
 			} catch (MalformedURLException e) {
 				rule.setUrl(null);
 			}
-			
+
 			// add the rule to the cache
 			rules.put(rule.getName(), rule);
 		}

--- a/src/main/java/hudson/plugins/violations/types/resharper/ReSharperParser.java
+++ b/src/main/java/hudson/plugins/violations/types/resharper/ReSharperParser.java
@@ -7,7 +7,6 @@ import hudson.plugins.violations.model.Severity;
 import hudson.plugins.violations.model.Violation;
 import hudson.plugins.violations.util.AbsoluteFileFinder;
 import hudson.plugins.violations.util.HashMapWithDefault;
-import hudson.util.IOException2;
 
 import java.io.File;
 import java.io.FileInputStream;
@@ -138,9 +137,9 @@ public class ReSharperParser implements ViolationsParser {
                 fullFileModel.addViolation(violation);
             }
         } catch (final ParserConfigurationException pce) {
-            throw new IOException2(pce);
+            throw new IOException(pce);
         } catch (final SAXException se) {
-            throw new IOException2(se);
+            throw new IOException(se);
         }
     }
 

--- a/src/main/java/hudson/plugins/violations/types/stylecop/StyleCopParser.java
+++ b/src/main/java/hudson/plugins/violations/types/stylecop/StyleCopParser.java
@@ -13,7 +13,6 @@ import javax.xml.parsers.ParserConfigurationException;
 
 import hudson.FilePath;
 import hudson.plugins.violations.parse.ParseUtil;
-import hudson.util.IOException2;
 import org.w3c.dom.Document;
 import org.w3c.dom.Element;
 import org.w3c.dom.NodeList;
@@ -29,10 +28,10 @@ import hudson.plugins.violations.model.Violation;
 
 /**
  * Parses a StyleCop (http://code.msdn.microsoft.com/sourceanalysis/) xml report file.
- * 
+ *
  */
 public class StyleCopParser implements ViolationsParser {
-    
+
     static final String TYPE_NAME = "stylecop";
     private FullBuildModel model;
     private File reportParentFile;
@@ -45,7 +44,7 @@ public class StyleCopParser implements ViolationsParser {
         this.reportParentFile = new File(fileName).getParentFile();
         if (this.reportParentFile==null)
             this.reportParentFile = projectPath;
-        
+
         DocumentBuilderFactory docBuilderFactory = DocumentBuilderFactory.newInstance();
         DocumentBuilder docBuilder;
         try {
@@ -61,15 +60,15 @@ public class StyleCopParser implements ViolationsParser {
 
             Element rootElement = (Element) mainNode.item(0);
             parseViolations(XmlElementUtil.getNamedChildElements(rootElement, "Violation"));
-            
-            findSourceFiles(model, projectPath.getPath(), sourcePaths);            
+
+            findSourceFiles(model, projectPath.getPath(), sourcePaths);
         } catch (ParserConfigurationException pce) {
-            throw new IOException2(pce);
+            throw new IOException(pce);
         } catch (SAXException se) {
-            throw new IOException2(se);
-        }    
+            throw new IOException(se);
+        }
     }
-    
+
     /**
      * Go through all violations and see if the source files can be found.
      * @param model model containing all violations
@@ -82,7 +81,7 @@ public class StyleCopParser implements ViolationsParser {
         if (sourcePaths != null) {
             finder.addSourcePaths(sourcePaths);
         }
-        
+
         Map<String, FullFileModel> fileModelMap = model.getFileModelMap();
         for (Map.Entry<String, FullFileModel> entry : fileModelMap.entrySet()) {
         	FullFileModel fileModel = entry.getValue();
@@ -93,7 +92,7 @@ public class StyleCopParser implements ViolationsParser {
             }
         }
     }
-    
+
     /***
      * Returns the value for the named attribute if it exists
      * @param element the element to check for an attribute
@@ -114,22 +113,22 @@ public class StyleCopParser implements ViolationsParser {
      */
     private void parseViolations(List<Element> elements) throws IOException {
         for (Element element : elements) {
-            
+
             Violation violation = new Violation();
             violation.setLine(getString(element, "LineNumber"));
             violation.setMessage(element.getTextContent() + " (" + getString(element, "RuleId") + ")");
             violation.setSeverity(Severity.MEDIUM);
             violation.setSeverityLevel(Severity.MEDIUM_VALUE);
             violation.setType(TYPE_NAME);
-            
+
             String temp = getString(element, "RuleNamespace");
             int i = temp.lastIndexOf('.');
             if (i != -1) {
                 violation.setSource(temp.substring(i));
             } else {
                 violation.setSource(getString(element,"RuleId"));
-            }            
-            
+            }
+
             // Add the violation to the model
             String displayName = new FilePath(reportParentFile).child(getString(element,"Source")).getRemote();
             displayName = ParseUtil.resolveAbsoluteName(reportParentFile,displayName);


### PR DESCRIPTION
## Remove usage of deprecated IOException2

Removes usage of deprecated `hudson.util.IOException2` by replacing it with `java.io.IOException`

### Testing done

None, rely on `ci.jenkins.io` to test it.

### Submitter checklist
- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [x] Link to relevant issues in GitHub or Jira
- [x] Link to relevant pull requests, esp. upstream and downstream changes
- [x] Ensure you have provided tests - that demonstrates feature works or fixes the issue
